### PR TITLE
updated polymer dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "iron-icon": "PolymerElements/iron-icon#~1.0.7",
     "iron-icons": "PolymerElements/iron-icons#~1.1.3",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#~1.0.9",
-    "polymer": "~1.2.4"
+    "polymer": "^1.2.4"
   },
   "license": "MIT",
   "homepage": "https://github.com/vangware/fontawesome-iconset",


### PR DESCRIPTION
Folks, fontawesome is using a too old version of Polymer on it's dependencies.
I update bower.json to use what ever newer version of Polymer a project is using.

I tested with Polymer 1.3.1 and fontawesome-icons is working fine.

cheers